### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,6 @@ sudo pip install python-snappy
 sudo pip install avro
 ```
 
-Note that a separate package is provided for Python3:
-
-```bash
-sudo pip3 install avro-python3
-```
-
 ### Python - start_server.py
 
 Run this first to start the python avro Mail server.


### PR DESCRIPTION
avro-python3 codebase was consolidated into the “avro” package and that supports both Python 2 and 3 now.

https://avro.apache.org/docs/1.11.1/getting-started-python/#notice-for-python-3-users